### PR TITLE
Add option to disable ranking of results entirely when using pg_search_scope.

### DIFF
--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -88,7 +88,7 @@ module PgSearch
     ].map(&:to_sym)
 
     VALID_VALUES = {
-      :ignoring => [:accents]
+      :ignoring => [:accents, :rank]
     }
 
     def assert_valid_options(options)

--- a/spec/integration/pg_search_spec.rb
+++ b/spec/integration/pg_search_spec.rb
@@ -1097,6 +1097,19 @@ describe "an Active Record model which includes PgSearch" do
       end
     end
 
+    context "ignoring rank" do
+      before do
+        ModelWithPgSearch.pg_search_scope :search_title_without_rank,
+          :against => :title,
+          :ignoring => :rank
+      end
+
+      it "does not use ts_rank in the query" do
+        sql = ModelWithPgSearch.search_title_without_rank("foobar").to_sql
+        expect(sql).to_not include "ts_rank"
+      end
+    end
+
     context "when passed a :ranked_by expression" do
       before do
         ModelWithPgSearch.pg_search_scope :search_content_with_default_rank,


### PR DESCRIPTION
Being able to disable ranking would be a major speed gain for some of our searches that don't really need ranking.

See https://github.com/Casecommons/pg_search/pull/259 for details.